### PR TITLE
Prevent error log spam regarding null being passed to dirname because…

### DIFF
--- a/src/GravityForms/ZGWAddon.php
+++ b/src/GravityForms/ZGWAddon.php
@@ -54,6 +54,13 @@ class ZGWAddon extends GFAddon
 	private static $_instance = null;
 
 	/**
+	 * The full path to the Add-On file.
+	 *
+	 * @var string
+	 */
+	protected $_full_path = __FILE__;
+
+	/**
 	 * @var string|array A string or an array of capabilities or roles that have access to the form settings
 	 */
 	protected $_capabilities_form_settings = array( 'gravityforms_edit_forms' );


### PR DESCRIPTION
This prevents the error log spam;

```
PHP Deprecated:  dirname(): Passing null to parameter #1 ($path) of type string is deprecated in [redacted]/plugins/gravityforms/includes/addon/class-gf-addon.php on line 6712
```