### PR TITLE
Fix typo in XXLLNC namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # OWC GravityForms ZGW
 
-> [!WARNING]
-> This plugin is under development, do not use in production environments.
-
 This plugin connects GravityForms with ZGW by using the owc/zgw-api package.
 In order for the connection(s) to work the ZGW registers must be configured on the settings page (/wp-admin/options-general.php?page=zgw_api_settings).
 

--- a/src/Clients/XXLLNC/Actions/CreateSubmissionPDFAction.php
+++ b/src/Clients/XXLLNC/Actions/CreateSubmissionPDFAction.php
@@ -7,7 +7,7 @@
  * @since   1.0.0
  */
 
-namespace OWCGravityFormsZGW\Clients\XXLNC\Actions;
+namespace OWCGravityFormsZGW\Clients\XXLLNC\Actions;
 
 /**
  * Exit when accessed directly.

--- a/src/Clients/XXLLNC/Actions/CreateUploadedDocumentsAction.php
+++ b/src/Clients/XXLLNC/Actions/CreateUploadedDocumentsAction.php
@@ -7,7 +7,7 @@
  * @since   1.0.0
  */
 
-namespace OWCGravityFormsZGW\Clients\XXLNC\Actions;
+namespace OWCGravityFormsZGW\Clients\XXLLNC\Actions;
 
 /**
  * Exit when accessed directly.

--- a/src/Clients/XXLLNC/Actions/CreateZaakAction.php
+++ b/src/Clients/XXLLNC/Actions/CreateZaakAction.php
@@ -7,7 +7,7 @@
  * @since   1.0.0
  */
 
-namespace OWCGravityFormsZGW\Clients\XXLNC\Actions;
+namespace OWCGravityFormsZGW\Clients\XXLLNC\Actions;
 
 /**
  * Exit when accessed directly.


### PR DESCRIPTION
There was an typo in the spelling of XXLLNC. I've also removed the notice in the README since the project is a lot further now.